### PR TITLE
code changes for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Welcome to Slate's fork of Coral! For wiki entries concerning this repo, see:
+- https://github.com/slategroup/slate-web/wiki/Comments-with-Coral-Talk
+- https://github.com/slategroup/slate-web/wiki/Setting-Up-Coral-(Comments)-Locally
+
 <p align="center">
   <a href="https://coralproject.net" target="_blank"><img width="250" src="https://docs.coralproject.net/img/coralproject_by_voxmedia.svg" alt="Coral by Vox Media" /></a>
 </p>

--- a/client/src/core/client/stream/constants.ts
+++ b/client/src/core/client/stream/constants.ts
@@ -6,7 +6,7 @@ export const POST_COMMENT_FORM_ID = "post-comment-form";
 
 export const MAX_REPLY_INDENT_DEPTH = 7;
 
-export const NUM_INITIAL_COMMENTS = 20; // has to be changed in tandem with AllCommentsTabContainer.tx
+export const NUM_INITIAL_COMMENTS = 10; // has to be changed in tandem with AllCommentsTabContainer.tx
 
 export const RTE_ELEMENT_ID = "Coral-RTE";
 

--- a/client/src/core/client/stream/constants.ts
+++ b/client/src/core/client/stream/constants.ts
@@ -6,7 +6,7 @@ export const POST_COMMENT_FORM_ID = "post-comment-form";
 
 export const MAX_REPLY_INDENT_DEPTH = 7;
 
-export const NUM_INITIAL_COMMENTS = 20;
+export const NUM_INITIAL_COMMENTS = 20; // has to be changed in tandem with AllCommentsTabContainer.tx
 
 export const RTE_ELEMENT_ID = "Coral-RTE";
 

--- a/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -244,18 +244,12 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
   );
 
   const commentSeenEnabled = useCommentSeenEnabled();
-  const [loadMore, isLoadingMore] = useLoadMore(relay, 99999);
+  // calling loadMore will query GraphQL for 20 more comments
+  const [loadMore, isLoadingMore] = useLoadMore(relay, 20); // 99999 instead of 20 will effectively load all remaining comments
   const beginLoadMoreEvent = useViewerNetworkEvent(LoadMoreAllCommentsEvent);
   const beginViewNewCommentsEvent = useViewerNetworkEvent(
     ViewNewCommentsNetworkEvent
   );
-
-  useEffect(() => {
-    setLocal({ commentsFullyLoaded: !hasMore });
-    if (hasMore && !isLoadingMore) {
-      void loadMoreAndEmit();
-    }
-  }, []);
 
   const loadMoreAndEmit = useCallback(async () => {
     const loadMoreEvent = beginLoadMoreEvent({
@@ -264,7 +258,6 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
     });
     try {
       await loadMore();
-      setLocal({ commentsFullyLoaded: true });
       loadMoreEvent.success();
     } catch (error) {
       loadMoreEvent.error({ message: error.message, code: error.code });
@@ -629,7 +622,9 @@ const enhanced = withPaginationContainer<
     story: graphql`
       fragment AllCommentsTabContainer_story on Story
       @argumentDefinitions(
-        count: { type: "Int", defaultValue: 20 }
+        # this count defines the number of comments that are initially requested
+        # from GraphQL and rendered on the page
+        count: { type: "Int", defaultValue: 5 }
         cursor: { type: "Cursor" }
         orderBy: { type: "COMMENT_SORT!", defaultValue: CREATED_AT_DESC }
         tag: { type: "TAG" }

--- a/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -246,7 +246,8 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
   const commentSeenEnabled = useCommentSeenEnabled();
   // calling loadMore will query GraphQL for 10 more comments
   // (at the time of this writing, pagination queries are quite slow
-  // and values higher than 10 sometimes take as long as 10 seconds)
+  // and values higher than 10 sometimes take as long as 10 seconds),
+  // depending on how many comment replies must be recursively fetched
   const [loadMore, isLoadingMore] = useLoadMore(relay, 10);
   const beginLoadMoreEvent = useViewerNetworkEvent(LoadMoreAllCommentsEvent);
   const beginViewNewCommentsEvent = useViewerNetworkEvent(

--- a/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -244,13 +244,16 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
   );
 
   const commentSeenEnabled = useCommentSeenEnabled();
-  // calling loadMore will query GraphQL for 20 more comments
-  const [loadMore, isLoadingMore] = useLoadMore(relay, 20); // 99999 instead of 20 will effectively load all remaining comments
+  // calling loadMore will query GraphQL for 10 more comments
+  // (at the time of this writing, pagination queries are quite slow
+  // and values higher than 10 sometimes take as long as 10 seconds)
+  const [loadMore, isLoadingMore] = useLoadMore(relay, 10);
   const beginLoadMoreEvent = useViewerNetworkEvent(LoadMoreAllCommentsEvent);
   const beginViewNewCommentsEvent = useViewerNetworkEvent(
     ViewNewCommentsNetworkEvent
   );
 
+  // this is called whenever user clicks 'Load More' button
   const loadMoreAndEmit = useCallback(async () => {
     const loadMoreEvent = beginLoadMoreEvent({
       storyID: story.id,
@@ -622,9 +625,10 @@ const enhanced = withPaginationContainer<
     story: graphql`
       fragment AllCommentsTabContainer_story on Story
       @argumentDefinitions(
-        # this count defines the number of comments that are initially requested
-        # from GraphQL and rendered on the page
-        count: { type: "Int", defaultValue: 5 }
+        # in the case that pagination is toggled on, this count defines
+        # the number of comments that are initially requested from GraphQL and rendered on the page
+        # the count value belowmust be changed in tandem with NUM_INITIAL_COMMENTS in constants.ts
+        count: { type: "Int", defaultValue: 10 }
         cursor: { type: "Cursor" }
         orderBy: { type: "COMMENT_SORT!", defaultValue: CREATED_AT_DESC }
         tag: { type: "TAG" }

--- a/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
@@ -1,5 +1,4 @@
 import { Localized } from "@fluent/react/compat";
-import cn from "classnames";
 import React, { FunctionComponent, useCallback, useMemo } from "react";
 import { graphql } from "react-relay";
 import { Virtuoso } from "react-virtuoso";
@@ -20,8 +19,6 @@ import { COMMENT_SORT } from "coral-stream/__generated__/AllCommentsTabContainer
 import { AllCommentsTabVirtualizedCommentsLocal } from "coral-stream/__generated__/AllCommentsTabVirtualizedCommentsLocal.graphql";
 
 import AllCommentsTabCommentContainer from "./AllCommentsTabCommentContainer";
-
-import styles from "./AllCommentsTabVirtualizedComments.css";
 
 interface Props {
   settings: AllCommentsTabContainer_settings;
@@ -145,8 +142,12 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
   const Footer = useCallback(() => {
     return (
       <>
-        {showLoadMoreForOldestFirstNewComments && (
-          <Localized id="comments-loadMore">
+        {(displayLoadAllButton || showLoadMoreForOldestFirstNewComments) && (
+          <Localized
+            id={
+              isLoadingMore ? "comments-loadAll-loading" : "comments-loadMore"
+            }
+          >
             <Button
               key={`comments-loadMore-${comments.length}`}
               id="comments-loadMore"
@@ -157,35 +158,6 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
               disabled={isLoadingMore}
               aria-controls="comments-allComments-log"
               className={CLASSES.allCommentsTabPane.loadMoreButton}
-              // Added for keyboard shortcut support.
-              data-key-stop
-              data-is-load-more
-            >
-              Load More
-            </Button>
-          </Localized>
-        )}
-        {displayLoadAllButton && (
-          <Localized
-            id={
-              loadAllButtonDisabled
-                ? "comments-loadAll-loading"
-                : "comments-loadMore"
-            }
-          >
-            <Button
-              key={`comments-loadAll-${comments.length}`}
-              id="comments-loadAll"
-              onClick={loadMoreAndEmit}
-              color="secondary"
-              variant="outlined"
-              fullWidth
-              disabled={!!loadAllButtonDisabled}
-              aria-controls="comments-allComments-log"
-              className={cn(
-                CLASSES.allCommentsTabPane.loadMoreButton,
-                styles.loadAll
-              )}
               // Added for keyboard shortcut support.
               data-key-stop
               data-is-load-more

--- a/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
@@ -82,10 +82,11 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
     const commentsOnLoad = { length: comments.length, hasMore };
     const commentsOnLoadLessThanInitialComments =
       commentsOnLoad.length < NUM_INITIAL_COMMENTS;
+
     return commentsOnLoadLessThanInitialComments
       ? false
       : commentsOnLoad.hasMore;
-  }, []);
+  }, [hasMore]); // watching for changes on hasMore to determine whether the Load More button should render
 
   // We determine whether to display the Load all comments button based on whether:
   // 1. If there are more comments to display than 20 AND fewer than 20 weren't initially loaded.
@@ -169,13 +170,13 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
             id={
               loadAllButtonDisabled
                 ? "comments-loadAll-loading"
-                : "comments-loadAll"
+                : "comments-loadMore"
             }
           >
             <Button
               key={`comments-loadAll-${comments.length}`}
               id="comments-loadAll"
-              onClick={onDisplayLoadAllButtonClick}
+              onClick={loadMoreAndEmit}
               color="secondary"
               variant="outlined"
               fullWidth
@@ -189,7 +190,7 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
               data-key-stop
               data-is-load-more
             >
-              Load All Comments
+              Load More
             </Button>
           </Localized>
         )}
@@ -222,11 +223,7 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
           top: increaseViewportBy,
           bottom: increaseViewportBy,
         }}
-        totalCount={
-          displayLoadAllButton
-            ? NUM_INITIAL_COMMENTS + newCommentsLength
-            : comments.length
-        }
+        totalCount={comments.length} // always render new comments as they get returned from GraphQL
         overscan={overscan}
         itemContent={useCallback(
           (index: number) => {

--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -505,6 +505,12 @@ const config = convict({
     default: ms("3000s"),
     env: "NOTIFICATIONS_POLL_RATE",
   },
+  pagination_count_threshold: {
+    doc: "the threshold number of comments above which pagination will be enabled",
+    format: Number,
+    default: 500,
+    env: "PAGINATION_COUNT_THRESHOLD",
+  }
 });
 
 export type Config = typeof config;

--- a/server/src/core/server/graph/loaders/Comments.ts
+++ b/server/src/core/server/graph/loaders/Comments.ts
@@ -482,6 +482,10 @@ export default (ctx: GraphContext) => ({
       throw new StoryNotFoundError(comment.storyID);
     }
 
+    // does this determine whether we keep querying for all comments on load?
+    // no doesn't seem to do anything
+    console.log('allChildComments retrieving all child comments (9999)')
+
     const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
     if (!cacheAvailable) {
       return retrieveChildrenForParentConnection(
@@ -489,7 +493,7 @@ export default (ctx: GraphContext) => ({
         ctx.tenant.id,
         comment,
         {
-          first: 9999,
+          first: 9999, // dev here 9999
           orderBy: defaultTo(orderBy, GQLCOMMENT_SORT.CREATED_AT_ASC),
         },
         story.isArchived

--- a/server/src/core/server/graph/loaders/Comments.ts
+++ b/server/src/core/server/graph/loaders/Comments.ts
@@ -482,10 +482,6 @@ export default (ctx: GraphContext) => ({
       throw new StoryNotFoundError(comment.storyID);
     }
 
-    // does this determine whether we keep querying for all comments on load?
-    // no doesn't seem to do anything
-    console.log('allChildComments retrieving all child comments (9999)')
-
     const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
     if (!cacheAvailable) {
       return retrieveChildrenForParentConnection(
@@ -493,7 +489,7 @@ export default (ctx: GraphContext) => ({
         ctx.tenant.id,
         comment,
         {
-          first: 9999, // dev here 9999
+          first: 9999,
           orderBy: defaultTo(orderBy, GQLCOMMENT_SORT.CREATED_AT_ASC),
         },
         story.isArchived

--- a/server/src/core/server/graph/loaders/Comments.ts
+++ b/server/src/core/server/graph/loaders/Comments.ts
@@ -352,15 +352,8 @@ export default (ctx: GraphContext) => ({
     const isArchived = !!(story.isArchived || story.isArchiving);
     const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
 
-    // the following code
-
-    // regardless of cacheAvailable, we want to paginate the first call to prevent loading all comments at once
-    // subsequent calls (for more is 15 comments) should retrieve from cache if the totalComments are fewer than 500
-    // and should paginate via mongo if the totalComments are greater than 500
-
-    // if the story is archived or has a relatively large number of comments,
-    // comments will be paginated via queries to Mongo
-
+    // Regardless of cacheAvailable (true when DATA_CACHE is enabled),
+    // we want to conditionally paginate the first call to prevent loading too many comments at once.
     if (
       !cacheAvailable ||
       isRatingsAndReviews(ctx.tenant, story) ||
@@ -510,7 +503,7 @@ export default (ctx: GraphContext) => ({
         ctx.tenant.id,
         comment,
         {
-          first: 9999, // seems like lowering this doesn't help reduce Redis operations
+          first: 9999,
           orderBy: defaultTo(orderBy, GQLCOMMENT_SORT.CREATED_AT_ASC),
         },
         story.isArchived

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -4328,7 +4328,7 @@ Comment is a comment left by a [User](/api/types/objects/User) on an
 [Story](/api/types/objects/Story) or another [Comment](/api/types/objects/Comment)
 as a reply.
 """
-type Comment @cacheControl(maxAge: 5) {
+type Comment @cacheControl(maxAge: 30) {
   """
   id is the identifier of the [Comment](/api/types/objects/Comment).
   """


### PR DESCRIPTION
Addresses https://github.com/slategroup/slate-web/issues/3731, as a follow-up to https://github.com/slategroup/slate-web/issues/2852.

With this PR, we follow Coral's guidance on implementing pagination on comment streams such that visitors to pages with very long comment threads (4000+) are not penalized by very slow render times. Following their suggestion for a solution to this was incomplete, however, due to the incompatibility between enabling `DATA_CACHE` (for Redis caching of comments) and pagination (which relies on querying Mongo). After some deliberation over our options, we arrived at the present PR, in which pagination is limited to comment streams that are over 500 comments long OR is archived. For all other cases, the Redis caching strategy enabled through the `DATA_CACHE` feature flag will be the pathway used to serve comments to readers, in which they will see all comments on page load.

The behavior described above diverges from the official release of Coral version 9.5.2 in that the official version will load all comments associated with the story on load. Our Open Thread pages commonly contain 20,000 comments, translating to a >20MB payload on page render. 

## Expected Behavior
- When a user visits an archived comment thread ([example](https://slate.com/briefing/2021/10/slates-open-thread-pepin-the-short.html)) with any number of comments, the comments will be paginated (they will see a `Load More` button)
- When a user visits a non-archived comment thread ([example](https://slate.com/comments/advice/2024/12/motherhood-freaky-part-care-and-feeding.html)) with 500 or fewer comments, all comments will load on page load.
- When a user visits a non-archived comment thread ([example](https://slate.com/briefing/2024/11/join-slates-open-thread-for-the-week-of-november-11.html)) with more than 500 comments, comments will be paginated.