### PR TITLE
fixing how we count total comments on a page for pagination

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "9.5.2",
+  "version": "9.5.3",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "9.5.3",
+  "version": "9.5.2",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [
@@ -21,7 +21,7 @@
   ],
   "description": "A better commenting experience from Vox Media.",
   "scripts": {
-    "build:client": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" ts-node --transpile-only ./scripts/build.ts",
+    "build:client": "GENERATE_SOURCEMAP=false NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch --max-old-space-size=8192\" ts-node --transpile-only ./scripts/build.ts",
     "build:development": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=development pnpm run --parallel generate build:client",
     "build:withProfiler": "NODE_ENV=production REACT_PROFILER=true pnpm run --parallel generate build:client",
     "build": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=production pnpm run generate-persist && pnpm run build:client",

--- a/server/src/core/server/graph/loaders/Comments.ts
+++ b/server/src/core/server/graph/loaders/Comments.ts
@@ -347,7 +347,7 @@ export default (ctx: GraphContext) => ({
       throw new StoryNotFoundError(storyID);
     }
 
-    const totalCommentsCount = story.commentCounts.tags.total;
+    const totalCommentsCount = story.commentCounts.status.APPROVED + story.commentCounts.status.NONE;
     const usePagination = totalCommentsCount > paginationCountThreshold;
     const isArchived = !!(story.isArchived || story.isArchiving);
     const cacheAvailable = await ctx.cache.available(ctx.tenant.id);


### PR DESCRIPTION
#### Description

Small update to how we count the number of comments on a page, which will in turn affect when we turn on pagination.

The data stored by Coral for an entries in the `stories` database in Mongo has a commentCounts property that looks contains an object called status that looks something like this
```
commentCounts: {
  status: {
    APPROVED: 7,
    NONE: 1250,
    PREMOD: 0,
    REJECTED: 16,
    SYSTEM_WITHHELD: 0
  }
}
```